### PR TITLE
Begin updating to 1.21.1

### DIFF
--- a/src/main/kotlin/org/blanketeconomy/Blanketeconomy.kt
+++ b/src/main/kotlin/org/blanketeconomy/Blanketeconomy.kt
@@ -14,10 +14,11 @@ import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.Text
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
-import net.minecraft.nbt.NbtList
-import net.minecraft.nbt.NbtString
 import org.blanketeconomy.Blanketconfig.config
 import me.lucko.fabric.api.permissions.v0.Permissions
+import net.minecraft.component.DataComponentTypes
+import net.minecraft.component.type.CustomModelDataComponent
+import net.minecraft.component.type.LoreComponent
 import org.blanketeconomy.utils.CustomColorParser
 import java.math.BigDecimal
 
@@ -235,17 +236,12 @@ class Blanketeconomy : ModInitializer {
 
             if (currencyConfig != null) {
                 val paperStack = ItemStack(Items.PAPER, amount).apply {
-                    orCreateNbt.putInt("CustomModelData", currencyConfig.custommodeldata)
+                    set(DataComponentTypes.CUSTOM_MODEL_DATA, CustomModelDataComponent(currencyConfig.custommodeldata))
 
-                    setCustomName(CustomColorParser.toNativeComponent(currencyConfig.name))
+                    set(DataComponentTypes.CUSTOM_NAME, CustomColorParser.toNativeComponent(currencyConfig.name))
 
-                    val displayTag = orCreateNbt.getCompound("display")
-                    val loreList = NbtList()
-
-                    loreList.add(NbtString.of(Text.Serializer.toJson(CustomColorParser.toNativeComponent(currencyConfig.lore))))
-
-                    displayTag.put("Lore", loreList)
-                    orCreateNbt.put("display", displayTag)
+                    val loreList: List<Text> = listOf(Text.literal(currencyConfig.lore))
+                    set(DataComponentTypes.LORE, LoreComponent(loreList))
                 }
 
                 player.inventory.offerOrDrop(paperStack)
@@ -286,8 +282,8 @@ class Blanketeconomy : ModInitializer {
     }
 
     private fun isCobbleCoin(stack: ItemStack, currencyType: String): Boolean {
-        val tag = stack.orCreateNbt
-        return tag.getInt("CustomModelData") == config.economy.find { it.currencyType == currencyType }?.custommodeldata
+        val data = stack.get(DataComponentTypes.CUSTOM_MODEL_DATA)?.value
+        return data == config.economy.find { it.currencyType == currencyType }?.custommodeldata
     }
 
     private fun initializePlayerData(player: ServerPlayerEntity) {

--- a/src/main/kotlin/org/blanketeconomy/utils/CustomColorParser.kt
+++ b/src/main/kotlin/org/blanketeconomy/utils/CustomColorParser.kt
@@ -3,6 +3,7 @@ package org.blanketeconomy.utils
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.minimessage.MiniMessage
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import net.minecraft.registry.BuiltinRegistries
 import net.minecraft.text.MutableText
 import net.minecraft.text.Text
 
@@ -14,7 +15,10 @@ object CustomColorParser {
     }
 
     private fun toNative(component: Component): Text? {
-        return Text.Serializer.fromJson(GsonComponentSerializer.gson().serialize(component))
+        val serializedComponent = GsonComponentSerializer.gson().serialize(component)
+
+        return Text.Serialization.fromJson(serializedComponent, BuiltinRegistries.createWrapperLookup())
+        //return Text.Serializer.fromJson(GsonComponentSerializer.gson().serialize(component))
     }
 
     private fun replaceNative(displayname: String): String {


### PR DESCRIPTION
The mod compiles and runs on 1.21.1, but commands seem to be unable to process Currency Type. 

For example, /beco pay <amount> <player> autofills normally, but the Currency Type does not. Even if I enter a Currency Type without autocomplete, the command still doesn't work. I'm not sure what's causing this issue. Maybe a newer version of fabric-permissions-api is required?

Because the commands are nonfunctional I'm not able to test if the code I provided actually works properly, but the initial 500 gold coins and 500 cobblecoins on first join did work as usual.